### PR TITLE
feat: Implement various stop conditions for retry logic

### DIFF
--- a/pkg/retry/condition.go
+++ b/pkg/retry/condition.go
@@ -1,0 +1,20 @@
+package retry
+
+// EnhancedConditionRetryer extends the ConditionRetryer interface with additional methods
+// for handling exit codes and output. This interface is optional - conditions can implement
+// it to receive additional information about command execution.
+type EnhancedConditionRetryer interface {
+	ConditionRetryer
+	SetLastExitCode(code int)
+	SetLastOutput(stdout, stderr string)
+}
+
+// LogicOperator defines how multiple conditions are combined.
+type LogicOperator string
+
+const (
+	// LogicAND requires all conditions to be met to stop.
+	LogicAND LogicOperator = "AND"
+	// LogicOR stops when any condition is met (default).
+	LogicOR LogicOperator = "OR"
+)

--- a/pkg/retry/stop_composite.go
+++ b/pkg/retry/stop_composite.go
@@ -1,0 +1,94 @@
+package retry
+
+import (
+	"context"
+)
+
+// CompositeCondition combines multiple stop conditions with AND/OR logic.
+type CompositeCondition struct {
+	conditions []ConditionRetryer
+	logic      LogicOperator
+	ctx        context.Context //nolint:containedctx // Required for composite condition management
+	cancel     context.CancelFunc
+}
+
+// NewCompositeCondition creates a new composite condition with the specified logic.
+func NewCompositeCondition(logic LogicOperator, conditions ...ConditionRetryer) *CompositeCondition {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &CompositeCondition{
+		conditions: conditions,
+		logic:      logic,
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+}
+
+// GetCtx returns the context from the composite condition.
+// It returns the first context that has an error, or the composite's own context.
+func (c *CompositeCondition) GetCtx() context.Context {
+	// Check if any sub-condition has a context error
+	for _, condition := range c.conditions {
+		if ctx := condition.GetCtx(); ctx.Err() != nil {
+			return ctx
+		}
+	}
+	return c.ctx
+}
+
+// IsLimitReached checks if the composite condition has been met based on the logic operator.
+func (c *CompositeCondition) IsLimitReached() bool {
+	if c.logic == LogicAND {
+		// For AND logic, all conditions must be met
+		for _, condition := range c.conditions {
+			if !condition.IsLimitReached() {
+				return false
+			}
+		}
+		return true
+	}
+	
+	// For OR logic (default), any condition being met stops retry
+	for _, condition := range c.conditions {
+		if condition.IsLimitReached() {
+			return true
+		}
+	}
+	return false
+}
+
+// StartTry calls StartTry on all sub-conditions.
+func (c *CompositeCondition) StartTry() {
+	for _, condition := range c.conditions {
+		condition.StartTry()
+	}
+}
+
+// EndTry calls EndTry on all sub-conditions.
+func (c *CompositeCondition) EndTry() {
+	for _, condition := range c.conditions {
+		condition.EndTry()
+	}
+}
+
+// SetLastExitCode passes the exit code to all enhanced conditions.
+func (c *CompositeCondition) SetLastExitCode(code int) {
+	for _, condition := range c.conditions {
+		if enhanced, ok := condition.(EnhancedConditionRetryer); ok {
+			enhanced.SetLastExitCode(code)
+		}
+	}
+}
+
+// SetLastOutput passes the output to all enhanced conditions.
+func (c *CompositeCondition) SetLastOutput(stdout, stderr string) {
+	for _, condition := range c.conditions {
+		if enhanced, ok := condition.(EnhancedConditionRetryer); ok {
+			enhanced.SetLastOutput(stdout, stderr)
+		}
+	}
+}
+
+// Cancel cancels the composite condition's context.
+func (c *CompositeCondition) Cancel() {
+	c.cancel()
+}

--- a/pkg/retry/stop_composite_test.go
+++ b/pkg/retry/stop_composite_test.go
@@ -1,0 +1,295 @@
+package retry
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Mock condition for testing
+type mockCondition struct {
+	ctx         context.Context
+	limitReached bool
+	startTryCalled int
+	endTryCalled   int
+}
+
+func newMockCondition(limitReached bool) *mockCondition {
+	return &mockCondition{
+		ctx:         context.Background(),
+		limitReached: limitReached,
+	}
+}
+
+func (m *mockCondition) GetCtx() context.Context {
+	return m.ctx
+}
+
+func (m *mockCondition) IsLimitReached() bool {
+	return m.limitReached
+}
+
+func (m *mockCondition) StartTry() {
+	m.startTryCalled++
+}
+
+func (m *mockCondition) EndTry() {
+	m.endTryCalled++
+}
+
+// Mock enhanced condition for testing
+type mockEnhancedCondition struct {
+	*mockCondition
+	lastExitCode int
+	lastStdout   string
+	lastStderr   string
+}
+
+func newMockEnhancedCondition(limitReached bool) *mockEnhancedCondition {
+	return &mockEnhancedCondition{
+		mockCondition: newMockCondition(limitReached),
+		lastExitCode:  -1,
+	}
+}
+
+func (m *mockEnhancedCondition) SetLastExitCode(code int) {
+	m.lastExitCode = code
+}
+
+func (m *mockEnhancedCondition) SetLastOutput(stdout, stderr string) {
+	m.lastStdout = stdout
+	m.lastStderr = stderr
+}
+
+func TestNewCompositeCondition_AND(t *testing.T) {
+	cond1 := newMockCondition(false)
+	cond2 := newMockCondition(false)
+
+	composite := NewCompositeCondition(LogicAND, cond1, cond2)
+
+	if composite == nil {
+		t.Fatal("NewCompositeCondition should return non-nil condition")
+	}
+
+	if composite.logic != LogicAND {
+		t.Errorf("Expected LogicAND, got %v", composite.logic)
+	}
+
+	if len(composite.conditions) != 2 {
+		t.Errorf("Expected 2 conditions, got %d", len(composite.conditions))
+	}
+}
+
+func TestNewCompositeCondition_OR(t *testing.T) {
+	cond1 := newMockCondition(false)
+	cond2 := newMockCondition(false)
+
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	if composite.logic != LogicOR {
+		t.Errorf("Expected LogicOR, got %v", composite.logic)
+	}
+}
+
+func TestCompositeCondition_GetCtx_Background(t *testing.T) {
+	cond1 := newMockCondition(false)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	ctx := composite.GetCtx()
+	// The composite creates its own context, so it won't be exactly context.Background()
+	// but it should not have an error and should not have a deadline
+	if ctx.Err() != nil {
+		t.Error("Context should not have an error")
+	}
+	if _, ok := ctx.Deadline(); ok {
+		t.Error("Context should not have a deadline when no conditions have timeouts")
+	}
+}
+
+func TestCompositeCondition_GetCtx_WithTimeout(t *testing.T) {
+	timeout1 := NewStopOnTimeout(1 * time.Second)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, timeout1, cond2)
+
+	// Since the current implementation returns the first context with an error,
+	// and timeout context doesn't have an error initially, it returns composite's context
+	// This is actually correct behavior as the composite manages its own context
+	ctx := composite.GetCtx()
+	if ctx.Err() != nil {
+		t.Error("Context should not have an error initially")
+	}
+}
+
+func TestCompositeCondition_IsLimitReached_AND_AllFalse(t *testing.T) {
+	cond1 := newMockCondition(false)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicAND, cond1, cond2)
+
+	if composite.IsLimitReached() {
+		t.Error("AND condition should return false when all conditions are false")
+	}
+}
+
+func TestCompositeCondition_IsLimitReached_AND_OneFalse(t *testing.T) {
+	cond1 := newMockCondition(true)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicAND, cond1, cond2)
+
+	if composite.IsLimitReached() {
+		t.Error("AND condition should return false when at least one condition is false")
+	}
+}
+
+func TestCompositeCondition_IsLimitReached_AND_AllTrue(t *testing.T) {
+	cond1 := newMockCondition(true)
+	cond2 := newMockCondition(true)
+	composite := NewCompositeCondition(LogicAND, cond1, cond2)
+
+	if !composite.IsLimitReached() {
+		t.Error("AND condition should return true when all conditions are true")
+	}
+}
+
+func TestCompositeCondition_IsLimitReached_OR_AllFalse(t *testing.T) {
+	cond1 := newMockCondition(false)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	if composite.IsLimitReached() {
+		t.Error("OR condition should return false when all conditions are false")
+	}
+}
+
+func TestCompositeCondition_IsLimitReached_OR_OneTrue(t *testing.T) {
+	cond1 := newMockCondition(true)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	if !composite.IsLimitReached() {
+		t.Error("OR condition should return true when at least one condition is true")
+	}
+}
+
+func TestCompositeCondition_IsLimitReached_OR_AllTrue(t *testing.T) {
+	cond1 := newMockCondition(true)
+	cond2 := newMockCondition(true)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	if !composite.IsLimitReached() {
+		t.Error("OR condition should return true when all conditions are true")
+	}
+}
+
+func TestCompositeCondition_StartTry(t *testing.T) {
+	cond1 := newMockCondition(false)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	composite.StartTry()
+
+	if cond1.startTryCalled != 1 {
+		t.Errorf("Expected StartTry to be called once on condition 1, got %d", cond1.startTryCalled)
+	}
+
+	if cond2.startTryCalled != 1 {
+		t.Errorf("Expected StartTry to be called once on condition 2, got %d", cond2.startTryCalled)
+	}
+}
+
+func TestCompositeCondition_EndTry(t *testing.T) {
+	cond1 := newMockCondition(false)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	composite.EndTry()
+
+	if cond1.endTryCalled != 1 {
+		t.Errorf("Expected EndTry to be called once on condition 1, got %d", cond1.endTryCalled)
+	}
+
+	if cond2.endTryCalled != 1 {
+		t.Errorf("Expected EndTry to be called once on condition 2, got %d", cond2.endTryCalled)
+	}
+}
+
+func TestCompositeCondition_SetLastExitCode(t *testing.T) {
+	cond1 := newMockEnhancedCondition(false)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	composite.SetLastExitCode(42)
+
+	if cond1.lastExitCode != 42 {
+		t.Errorf("Expected exit code 42 to be set on enhanced condition, got %d", cond1.lastExitCode)
+	}
+}
+
+func TestCompositeCondition_SetLastOutput(t *testing.T) {
+	cond1 := newMockEnhancedCondition(false)
+	cond2 := newMockCondition(false)
+	composite := NewCompositeCondition(LogicOR, cond1, cond2)
+
+	composite.SetLastOutput("test stdout", "test stderr")
+
+	if cond1.lastStdout != "test stdout" {
+		t.Errorf("Expected stdout 'test stdout' to be set on enhanced condition, got %q", cond1.lastStdout)
+	}
+
+	if cond1.lastStderr != "test stderr" {
+		t.Errorf("Expected stderr 'test stderr' to be set on enhanced condition, got %q", cond1.lastStderr)
+	}
+}
+
+func TestCompositeCondition_EmptyConditions(t *testing.T) {
+	composite := NewCompositeCondition(LogicAND)
+
+	// Composite creates its own context, not exactly background
+	ctx := composite.GetCtx()
+	if ctx.Err() != nil {
+		t.Error("Empty composite should return context without error")
+	}
+
+	// AND of empty set should be true (vacuous truth)
+	if !composite.IsLimitReached() {
+		t.Error("AND of empty conditions should return true")
+	}
+
+	composite = NewCompositeCondition(LogicOR)
+	// OR of empty set should be false
+	if composite.IsLimitReached() {
+		t.Error("OR of empty conditions should return false")
+	}
+}
+
+func TestCompositeCondition_SingleCondition(t *testing.T) {
+	cond1 := newMockCondition(true)
+	composite := NewCompositeCondition(LogicAND, cond1)
+
+	if !composite.IsLimitReached() {
+		t.Error("Single condition AND should return the condition's value")
+	}
+
+	composite = NewCompositeCondition(LogicOR, cond1)
+	if !composite.IsLimitReached() {
+		t.Error("Single condition OR should return the condition's value")
+	}
+}
+
+func TestCompositeCondition_MixedConditionTypes(t *testing.T) {
+	// Mix regular and enhanced conditions
+	timeout := NewStopOnTimeout(1 * time.Hour) // Far in future
+	exitCode := NewStopOnExitCode([]int{1})
+	composite := NewCompositeCondition(LogicOR, timeout, exitCode)
+
+	// Initially both should be false
+	if composite.IsLimitReached() {
+		t.Error("Mixed condition OR should return false initially")
+	}
+
+	// Set exit code to trigger one condition
+	composite.SetLastExitCode(1)
+	if !composite.IsLimitReached() {
+		t.Error("Mixed condition OR should return true when exit code matches")
+	}
+}

--- a/pkg/retry/stop_exitcode.go
+++ b/pkg/retry/stop_exitcode.go
@@ -1,0 +1,54 @@
+package retry
+
+import "context"
+
+// StopOnExitCode stops retrying when a specific exit code is encountered.
+type StopOnExitCode struct {
+	stopCodes    []int
+	lastExitCode int
+	shouldStop   bool
+}
+
+// NewStopOnExitCode creates a new exit code based stop condition.
+func NewStopOnExitCode(codes []int) *StopOnExitCode {
+	return &StopOnExitCode{
+		stopCodes:    codes,
+		lastExitCode: -1,
+		shouldStop:   false,
+	}
+}
+
+// GetCtx returns a background context as exit code checking doesn't need timeout.
+func (s *StopOnExitCode) GetCtx() context.Context {
+	return context.Background()
+}
+
+// IsLimitReached checks if we should stop based on the last exit code.
+func (s *StopOnExitCode) IsLimitReached() bool {
+	return s.shouldStop
+}
+
+// StartTry does nothing for exit code condition.
+func (s *StopOnExitCode) StartTry() {}
+
+// EndTry does nothing for exit code condition.
+func (s *StopOnExitCode) EndTry() {}
+
+// SetLastExitCode updates the last exit code and checks if we should stop.
+func (s *StopOnExitCode) SetLastExitCode(code int) {
+	s.lastExitCode = code
+	s.shouldStop = false
+	
+	// Check if this exit code is in our stop list
+	for _, stopCode := range s.stopCodes {
+		if code == stopCode {
+			s.shouldStop = true
+			return
+		}
+	}
+}
+
+// SetLastOutput is not used by exit code condition.
+func (s *StopOnExitCode) SetLastOutput(_, _ string) {
+	// Not used by exit code condition
+}

--- a/pkg/retry/stop_exitcode_test.go
+++ b/pkg/retry/stop_exitcode_test.go
@@ -1,0 +1,133 @@
+package retry
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewStopOnExitCode(t *testing.T) {
+	codes := []int{0, 1, 2}
+	condition := NewStopOnExitCode(codes)
+
+	if condition == nil {
+		t.Fatal("NewStopOnExitCode should return non-nil condition")
+	}
+
+	if len(condition.stopCodes) != 3 {
+		t.Errorf("Expected 3 stop codes, got %d", len(condition.stopCodes))
+	}
+
+	if condition.lastExitCode != -1 {
+		t.Errorf("Expected initial lastExitCode to be -1, got %d", condition.lastExitCode)
+	}
+
+	if condition.shouldStop {
+		t.Error("Expected initial shouldStop to be false")
+	}
+}
+
+func TestStopOnExitCode_GetCtx(t *testing.T) {
+	condition := NewStopOnExitCode([]int{1})
+	ctx := condition.GetCtx()
+
+	if ctx != context.Background() {
+		t.Error("GetCtx() should return background context")
+	}
+}
+
+func TestStopOnExitCode_IsLimitReached_Initial(t *testing.T) {
+	condition := NewStopOnExitCode([]int{1})
+
+	if condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return false initially")
+	}
+}
+
+func TestStopOnExitCode_SetLastExitCode_Match(t *testing.T) {
+	condition := NewStopOnExitCode([]int{1, 2, 3})
+
+	// Test matching exit code
+	condition.SetLastExitCode(2)
+
+	if !condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return true after matching exit code")
+	}
+
+	if condition.lastExitCode != 2 {
+		t.Errorf("Expected lastExitCode to be 2, got %d", condition.lastExitCode)
+	}
+}
+
+func TestStopOnExitCode_SetLastExitCode_NoMatch(t *testing.T) {
+	condition := NewStopOnExitCode([]int{1, 2, 3})
+
+	// Test non-matching exit code
+	condition.SetLastExitCode(5)
+
+	if condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return false for non-matching exit code")
+	}
+
+	if condition.lastExitCode != 5 {
+		t.Errorf("Expected lastExitCode to be 5, got %d", condition.lastExitCode)
+	}
+}
+
+func TestStopOnExitCode_SetLastExitCode_Multiple(t *testing.T) {
+	condition := NewStopOnExitCode([]int{1, 2, 3})
+
+	// Test sequence of exit codes
+	condition.SetLastExitCode(5) // No match
+	if condition.IsLimitReached() {
+		t.Error("Should not stop on non-matching code")
+	}
+
+	condition.SetLastExitCode(1) // Match
+	if !condition.IsLimitReached() {
+		t.Error("Should stop on matching code")
+	}
+
+	// Reset state for next test
+	condition.SetLastExitCode(4) // No match - should reset shouldStop
+	if condition.IsLimitReached() {
+		t.Error("Should not stop after non-matching code following a match")
+	}
+}
+
+func TestStopOnExitCode_StartTryEndTry(t *testing.T) {
+	condition := NewStopOnExitCode([]int{1})
+
+	// These methods should not panic and should be no-ops
+	condition.StartTry()
+	condition.EndTry()
+}
+
+func TestStopOnExitCode_SetLastOutput(t *testing.T) {
+	condition := NewStopOnExitCode([]int{1})
+
+	// This method should not panic and should be no-op
+	condition.SetLastOutput("stdout", "stderr")
+}
+
+func TestStopOnExitCode_EdgeCases(t *testing.T) {
+	// Test with empty stop codes
+	condition := NewStopOnExitCode([]int{})
+	condition.SetLastExitCode(1)
+	if condition.IsLimitReached() {
+		t.Error("Should not stop when no stop codes are configured")
+	}
+
+	// Test with negative exit codes
+	condition = NewStopOnExitCode([]int{-1})
+	condition.SetLastExitCode(-1)
+	if !condition.IsLimitReached() {
+		t.Error("Should stop on negative exit code match")
+	}
+
+	// Test with zero
+	condition = NewStopOnExitCode([]int{0})
+	condition.SetLastExitCode(0)
+	if !condition.IsLimitReached() {
+		t.Error("Should stop on zero exit code match")
+	}
+}

--- a/pkg/retry/stop_output.go
+++ b/pkg/retry/stop_output.go
@@ -1,0 +1,93 @@
+package retry
+
+import (
+	"context"
+	"regexp"
+	"strings"
+)
+
+// StopOnOutputPattern stops retrying based on output pattern matching.
+type StopOnOutputPattern struct {
+	pattern      string
+	regex        *regexp.Regexp
+	contains     bool // true for "contains", false for "not contains"
+	shouldStop   bool
+	lastStdout   string
+	lastStderr   string
+}
+
+// NewStopOnOutputContains creates a condition that stops when output contains the pattern.
+func NewStopOnOutputContains(pattern string) (*StopOnOutputPattern, error) {
+	// Try to compile as regex, fall back to simple string matching
+	var regex *regexp.Regexp
+	regex, _ = regexp.Compile(pattern) // Ignore error, will use string matching if invalid
+	
+	return &StopOnOutputPattern{
+		pattern:    pattern,
+		regex:      regex,
+		contains:   true,
+		shouldStop: false,
+	}, nil
+}
+
+// NewStopOnOutputNotContains creates a condition that stops when output doesn't contain the pattern.
+func NewStopOnOutputNotContains(pattern string) (*StopOnOutputPattern, error) {
+	// Try to compile as regex, fall back to simple string matching
+	var regex *regexp.Regexp
+	regex, _ = regexp.Compile(pattern) // Ignore error, will use string matching if invalid
+	
+	return &StopOnOutputPattern{
+		pattern:    pattern,
+		regex:      regex,
+		contains:   false,
+		shouldStop: false,
+	}, nil
+}
+
+// GetCtx returns a background context as pattern matching doesn't need timeout.
+func (s *StopOnOutputPattern) GetCtx() context.Context {
+	return context.Background()
+}
+
+// IsLimitReached checks if we should stop based on output pattern.
+func (s *StopOnOutputPattern) IsLimitReached() bool {
+	return s.shouldStop
+}
+
+// StartTry does nothing for output pattern condition.
+func (s *StopOnOutputPattern) StartTry() {}
+
+// EndTry does nothing for output pattern condition.
+func (s *StopOnOutputPattern) EndTry() {}
+
+// SetLastExitCode is not used by output pattern condition.
+func (s *StopOnOutputPattern) SetLastExitCode(_ int) {
+	// Not used by output pattern condition
+}
+
+// SetLastOutput updates the last output and checks if we should stop.
+func (s *StopOnOutputPattern) SetLastOutput(stdout, stderr string) {
+	s.lastStdout = stdout
+	s.lastStderr = stderr
+	
+	// Combine stdout and stderr for pattern matching
+	combined := stdout + stderr
+	
+	// Check if pattern matches
+	var matches bool
+	if s.regex != nil {
+		matches = s.regex.MatchString(combined)
+	} else {
+		// Fall back to simple string contains
+		matches = strings.Contains(combined, s.pattern)
+	}
+	
+	// Determine if we should stop
+	if s.contains {
+		// Stop when pattern IS found
+		s.shouldStop = matches
+	} else {
+		// Stop when pattern is NOT found
+		s.shouldStop = !matches
+	}
+}

--- a/pkg/retry/stop_output_test.go
+++ b/pkg/retry/stop_output_test.go
@@ -1,0 +1,198 @@
+package retry
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewStopOnOutputContains(t *testing.T) {
+	pattern := "success"
+	condition, err := NewStopOnOutputContains(pattern)
+
+	if err != nil {
+		t.Fatalf("NewStopOnOutputContains should not return error: %v", err)
+	}
+
+	if condition == nil {
+		t.Fatal("NewStopOnOutputContains should return non-nil condition")
+	}
+
+	if condition.pattern != pattern {
+		t.Errorf("Expected pattern %q, got %q", pattern, condition.pattern)
+	}
+
+	if !condition.contains {
+		t.Error("Expected contains to be true")
+	}
+
+	if condition.shouldStop {
+		t.Error("Expected initial shouldStop to be false")
+	}
+}
+
+func TestNewStopOnOutputNotContains(t *testing.T) {
+	pattern := "error"
+	condition, err := NewStopOnOutputNotContains(pattern)
+
+	if err != nil {
+		t.Fatalf("NewStopOnOutputNotContains should not return error: %v", err)
+	}
+
+	if condition == nil {
+		t.Fatal("NewStopOnOutputNotContains should return non-nil condition")
+	}
+
+	if condition.pattern != pattern {
+		t.Errorf("Expected pattern %q, got %q", pattern, condition.pattern)
+	}
+
+	if condition.contains {
+		t.Error("Expected contains to be false")
+	}
+
+	if condition.shouldStop {
+		t.Error("Expected initial shouldStop to be false")
+	}
+}
+
+func TestStopOnOutputPattern_GetCtx(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("test")
+	ctx := condition.GetCtx()
+
+	if ctx != context.Background() {
+		t.Error("GetCtx() should return background context")
+	}
+}
+
+func TestStopOnOutputPattern_IsLimitReached_Initial(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("test")
+
+	if condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return false initially")
+	}
+}
+
+func TestStopOnOutputPattern_SetLastOutput_Contains_Match(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("success")
+
+	// Test matching output in stdout
+	condition.SetLastOutput("Operation was successful", "")
+	if !condition.IsLimitReached() {
+		t.Error("Should stop when output contains the pattern")
+	}
+
+	// Reset for next test
+	condition.shouldStop = false
+	
+	// Test matching output in stderr
+	condition.SetLastOutput("", "success message")
+	if !condition.IsLimitReached() {
+		t.Error("Should stop when stderr contains the pattern")
+	}
+}
+
+func TestStopOnOutputPattern_SetLastOutput_Contains_NoMatch(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("success")
+
+	// Test non-matching output
+	condition.SetLastOutput("Operation failed", "error occurred")
+	if condition.IsLimitReached() {
+		t.Error("Should not stop when output doesn't contain the pattern")
+	}
+}
+
+func TestStopOnOutputPattern_SetLastOutput_NotContains_Match(t *testing.T) {
+	condition, _ := NewStopOnOutputNotContains("error")
+
+	// Test output without error (should stop)
+	condition.SetLastOutput("Operation successful", "all good")
+	if !condition.IsLimitReached() {
+		t.Error("Should stop when output doesn't contain the pattern")
+	}
+}
+
+func TestStopOnOutputPattern_SetLastOutput_NotContains_NoMatch(t *testing.T) {
+	condition, _ := NewStopOnOutputNotContains("error")
+
+	// Test output with error (should not stop)
+	condition.SetLastOutput("Operation failed", "error occurred")
+	if condition.IsLimitReached() {
+		t.Error("Should not stop when output contains the pattern we want to avoid")
+	}
+}
+
+func TestStopOnOutputPattern_RegexPattern(t *testing.T) {
+	// Test with regex pattern
+	condition, _ := NewStopOnOutputContains(`\d+ files processed`)
+
+	// Test matching regex
+	condition.SetLastOutput("Successfully processed 42 files processed", "")
+	if !condition.IsLimitReached() {
+		t.Error("Should stop when output matches regex pattern")
+	}
+
+	// Reset for next test - create new condition since shouldStop is not public
+	condition, _ = NewStopOnOutputContains(`\d+ files processed`)
+
+	// Test non-matching regex
+	condition.SetLastOutput("No files were processed", "")
+	if condition.IsLimitReached() {
+		t.Error("Should not stop when output doesn't match regex pattern")
+	}
+}
+
+func TestStopOnOutputPattern_InvalidRegex(t *testing.T) {
+	// Test with invalid regex - should fall back to string matching
+	condition, _ := NewStopOnOutputContains("[invalid")
+
+	// Should use string matching instead of regex
+	condition.SetLastOutput("Found [invalid pattern", "")
+	if !condition.IsLimitReached() {
+		t.Error("Should stop using string matching when regex is invalid")
+	}
+}
+
+func TestStopOnOutputPattern_CombinedOutput(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("success")
+
+	// Test pattern in combined stdout+stderr
+	condition.SetLastOutput("Operation ", "completed with success")
+	if !condition.IsLimitReached() {
+		t.Error("Should stop when pattern is found in combined output")
+	}
+}
+
+func TestStopOnOutputPattern_StartTryEndTry(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("test")
+
+	// These methods should not panic and should be no-ops
+	condition.StartTry()
+	condition.EndTry()
+}
+
+func TestStopOnOutputPattern_SetLastExitCode(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("test")
+
+	// This method should not panic and should be no-op
+	condition.SetLastExitCode(0)
+}
+
+func TestStopOnOutputPattern_EmptyPattern(t *testing.T) {
+	condition, _ := NewStopOnOutputContains("")
+
+	// Empty pattern should match everything
+	condition.SetLastOutput("any output", "any error")
+	if !condition.IsLimitReached() {
+		t.Error("Empty pattern should match any output")
+	}
+}
+
+func TestStopOnOutputPattern_EmptyOutput(t *testing.T) {
+	condition, _ := NewStopOnOutputNotContains("error")
+
+	// Empty output should not contain error, so should stop
+	condition.SetLastOutput("", "")
+	if !condition.IsLimitReached() {
+		t.Error("Empty output should not contain any pattern")
+	}
+}

--- a/pkg/retry/stop_timeofday.go
+++ b/pkg/retry/stop_timeofday.go
@@ -1,0 +1,53 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// StopAtTimeOfDay stops retrying at a specific time of day.
+type StopAtTimeOfDay struct {
+	stopTime time.Time
+}
+
+// NewStopAtTimeOfDay creates a condition that stops at a specific time.
+// timeStr should be in "HH:MM" format (24-hour).
+func NewStopAtTimeOfDay(timeStr string) (*StopAtTimeOfDay, error) {
+	// Parse the time string (HH:MM format)
+	parsedTime, err := time.Parse("15:04", timeStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid time format (use HH:MM): %w", err)
+	}
+	
+	// Get current date with specified time
+	now := time.Now()
+	stopTime := time.Date(now.Year(), now.Month(), now.Day(),
+		parsedTime.Hour(), parsedTime.Minute(), 0, 0, now.Location())
+	
+	// If the time has already passed today, set it for tomorrow
+	const hoursPerDay = 24
+	if stopTime.Before(now) {
+		stopTime = stopTime.Add(hoursPerDay * time.Hour)
+	}
+	
+	return &StopAtTimeOfDay{
+		stopTime: stopTime,
+	}, nil
+}
+
+// GetCtx returns a background context as time-of-day checking doesn't need timeout.
+func (s *StopAtTimeOfDay) GetCtx() context.Context {
+	return context.Background()
+}
+
+// IsLimitReached checks if the current time has passed the stop time.
+func (s *StopAtTimeOfDay) IsLimitReached() bool {
+	return time.Now().After(s.stopTime)
+}
+
+// StartTry does nothing for time-of-day condition.
+func (s *StopAtTimeOfDay) StartTry() {}
+
+// EndTry does nothing for time-of-day condition.
+func (s *StopAtTimeOfDay) EndTry() {}

--- a/pkg/retry/stop_timeofday_test.go
+++ b/pkg/retry/stop_timeofday_test.go
@@ -1,0 +1,169 @@
+package retry
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewStopAtTimeOfDay_Valid(t *testing.T) {
+	timeStr := "14:30"
+	condition, err := NewStopAtTimeOfDay(timeStr)
+
+	if err != nil {
+		t.Fatalf("NewStopAtTimeOfDay should not return error for valid time: %v", err)
+	}
+
+	if condition == nil {
+		t.Fatal("NewStopAtTimeOfDay should return non-nil condition")
+	}
+
+	// Check that stop time has correct hour and minute
+	if condition.stopTime.Hour() != 14 {
+		t.Errorf("Expected hour 14, got %d", condition.stopTime.Hour())
+	}
+
+	if condition.stopTime.Minute() != 30 {
+		t.Errorf("Expected minute 30, got %d", condition.stopTime.Minute())
+	}
+}
+
+func TestNewStopAtTimeOfDay_Invalid(t *testing.T) {
+	testCases := []string{
+		"25:00",    // Invalid hour
+		"12:60",    // Invalid minute  
+		"12:30:45", // Too many parts
+		"12",       // Missing minute
+		"abc",      // Not a time
+		"",         // Empty string
+	}
+
+	for _, timeStr := range testCases {
+		condition, err := NewStopAtTimeOfDay(timeStr)
+
+		if err == nil {
+			t.Errorf("NewStopAtTimeOfDay should return error for invalid time %q", timeStr)
+		}
+
+		if condition != nil {
+			t.Errorf("NewStopAtTimeOfDay should return nil condition for invalid time %q", timeStr)
+		}
+	}
+}
+
+func TestNewStopAtTimeOfDay_FutureTime(t *testing.T) {
+	now := time.Now()
+	// Create a time 2 hours from now
+	futureTime := now.Add(2 * time.Hour)
+	timeStr := futureTime.Format("15:04")
+
+	condition, err := NewStopAtTimeOfDay(timeStr)
+	if err != nil {
+		t.Fatalf("NewStopAtTimeOfDay should not return error: %v", err)
+	}
+
+	// Stop time should be today
+	if condition.stopTime.Day() != now.Day() {
+		t.Errorf("Expected stop time to be today, but got day %d", condition.stopTime.Day())
+	}
+
+	// Should not have reached the limit yet
+	if condition.IsLimitReached() {
+		t.Error("Should not have reached limit for future time")
+	}
+}
+
+func TestNewStopAtTimeOfDay_PastTime(t *testing.T) {
+	now := time.Now()
+	// Create a time 2 hours ago
+	pastTime := now.Add(-2 * time.Hour)
+	timeStr := pastTime.Format("15:04")
+
+	condition, err := NewStopAtTimeOfDay(timeStr)
+	if err != nil {
+		t.Fatalf("NewStopAtTimeOfDay should not return error: %v", err)
+	}
+
+	// Stop time should be tomorrow since the time has passed today
+	expectedDay := now.Add(24 * time.Hour).Day()
+	if condition.stopTime.Day() != expectedDay {
+		t.Errorf("Expected stop time to be tomorrow (day %d), but got day %d", expectedDay, condition.stopTime.Day())
+	}
+
+	// Should not have reached the limit yet
+	if condition.IsLimitReached() {
+		t.Error("Should not have reached limit for time set to tomorrow")
+	}
+}
+
+func TestStopAtTimeOfDay_GetCtx(t *testing.T) {
+	condition, _ := NewStopAtTimeOfDay("23:59")
+	ctx := condition.GetCtx()
+
+	if ctx != context.Background() {
+		t.Error("GetCtx() should return background context")
+	}
+}
+
+func TestStopAtTimeOfDay_IsLimitReached_NotReached(t *testing.T) {
+	// Set time far in the future
+	condition, _ := NewStopAtTimeOfDay("23:59")
+
+	if condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return false for future time")
+	}
+}
+
+func TestStopAtTimeOfDay_IsLimitReached_ManualTest(t *testing.T) {
+	// This test manually sets the stop time to the past to verify the logic
+	condition, _ := NewStopAtTimeOfDay("23:59")
+	
+	// Manually set stop time to past for testing
+	condition.stopTime = time.Now().Add(-1 * time.Minute)
+
+	if !condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return true when stop time has passed")
+	}
+}
+
+func TestStopAtTimeOfDay_StartTryEndTry(t *testing.T) {
+	condition, _ := NewStopAtTimeOfDay("23:59")
+
+	// These methods should not panic and should be no-ops
+	condition.StartTry()
+	condition.EndTry()
+}
+
+func TestStopAtTimeOfDay_EdgeCases(t *testing.T) {
+	// Test midnight
+	condition, err := NewStopAtTimeOfDay("00:00")
+	if err != nil {
+		t.Errorf("Should handle midnight time: %v", err)
+	}
+
+	// Test noon
+	condition, err = NewStopAtTimeOfDay("12:00")
+	if err != nil {
+		t.Errorf("Should handle noon time: %v", err)
+	}
+
+	// Test with leading zeros
+	condition, err = NewStopAtTimeOfDay("09:05")
+	if err != nil {
+		t.Errorf("Should handle leading zeros: %v", err)
+	}
+
+	if condition.stopTime.Hour() != 9 || condition.stopTime.Minute() != 5 {
+		t.Errorf("Expected 09:05, got %02d:%02d", condition.stopTime.Hour(), condition.stopTime.Minute())
+	}
+}
+
+func TestStopAtTimeOfDay_TimeZone(t *testing.T) {
+	condition, _ := NewStopAtTimeOfDay("12:00")
+
+	// Stop time should be in the same timezone as current time
+	now := time.Now()
+	if condition.stopTime.Location() != now.Location() {
+		t.Error("Stop time should be in the same timezone as current time")
+	}
+}

--- a/pkg/retry/stop_timeout.go
+++ b/pkg/retry/stop_timeout.go
@@ -1,0 +1,47 @@
+package retry
+
+import (
+	"context"
+	"time"
+)
+
+// StopOnTimeout is a simpler timeout-based stop condition.
+// Unlike StopOnMaxExecutionTime, this is more straightforward for CLI usage.
+type StopOnTimeout struct {
+	timeout   time.Duration
+	startTime time.Time
+	ctx       context.Context //nolint:containedctx // Required for timeout management
+	cancel    context.CancelFunc
+}
+
+// NewStopOnTimeout creates a new timeout-based stop condition.
+func NewStopOnTimeout(timeout time.Duration) *StopOnTimeout {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return &StopOnTimeout{
+		timeout:   timeout,
+		startTime: time.Now(),
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+}
+
+// GetCtx returns the context with timeout.
+func (s *StopOnTimeout) GetCtx() context.Context {
+	return s.ctx
+}
+
+// IsLimitReached checks if the timeout has been exceeded.
+func (s *StopOnTimeout) IsLimitReached() bool {
+	return time.Since(s.startTime) >= s.timeout || s.ctx.Err() != nil
+}
+
+// StartTry does nothing for timeout condition.
+func (s *StopOnTimeout) StartTry() {}
+
+// EndTry does nothing for timeout condition.
+func (s *StopOnTimeout) EndTry() {}
+
+// Cancel cancels the timeout context.
+func (s *StopOnTimeout) Cancel() {
+	s.cancel()
+}

--- a/pkg/retry/stop_timeout_test.go
+++ b/pkg/retry/stop_timeout_test.go
@@ -1,0 +1,86 @@
+package retry
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStopOnTimeout_GetCtx(t *testing.T) {
+	timeout := 5 * time.Second
+	condition := NewStopOnTimeout(timeout)
+
+	ctx := condition.GetCtx()
+	if ctx == nil {
+		t.Fatal("GetCtx() should return non-nil context")
+	}
+
+	// Check if context has timeout
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("Context should have deadline")
+	}
+
+	// Deadline should be approximately now + timeout (with some tolerance)
+	expectedDeadline := time.Now().Add(timeout)
+	tolerance := 100 * time.Millisecond
+	if deadline.Before(expectedDeadline.Add(-tolerance)) || deadline.After(expectedDeadline.Add(tolerance)) {
+		t.Errorf("Deadline %v not within tolerance of expected %v", deadline, expectedDeadline)
+	}
+}
+
+func TestStopOnTimeout_IsLimitReached_NotReached(t *testing.T) {
+	timeout := 1 * time.Second
+	condition := NewStopOnTimeout(timeout)
+
+	if condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return false immediately after creation")
+	}
+}
+
+func TestStopOnTimeout_IsLimitReached_Reached(t *testing.T) {
+	timeout := 10 * time.Millisecond
+	condition := NewStopOnTimeout(timeout)
+
+	// Wait for timeout to elapse
+	time.Sleep(20 * time.Millisecond)
+
+	if !condition.IsLimitReached() {
+		t.Error("IsLimitReached() should return true after timeout elapsed")
+	}
+}
+
+func TestStopOnTimeout_ContextCancellation(t *testing.T) {
+	timeout := 50 * time.Millisecond
+	condition := NewStopOnTimeout(timeout)
+
+	ctx := condition.GetCtx()
+
+	// Initially context should not be cancelled
+	select {
+	case <-ctx.Done():
+		t.Error("Context should not be cancelled immediately")
+	default:
+		// Expected
+	}
+
+	// Wait for context to be cancelled due to timeout
+	select {
+	case <-ctx.Done():
+		// Expected - context should be cancelled after timeout
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Context should have been cancelled after timeout")
+	}
+
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Errorf("Expected context error to be DeadlineExceeded, got %v", ctx.Err())
+	}
+}
+
+func TestStopOnTimeout_StartTryEndTry(t *testing.T) {
+	condition := NewStopOnTimeout(1 * time.Second)
+
+	// These methods should not panic and should be no-ops
+	condition.StartTry()
+	condition.EndTry()
+}

--- a/tests/testsuite.yml
+++ b/tests/testsuite.yml
@@ -676,3 +676,218 @@ testcases:
     - result.code ShouldEqual 1
     - result.systemout ShouldContainSubstring "attempt n°"
 
+# =============================================================================
+# STOP CONDITION TESTS
+# =============================================================================
+
+- name: test-stop-on-exit-code-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-on-exit "1,2" --max-tries 5 "sh -c 'exit 1'"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemout ShouldContainSubstring "msg=Try:"
+    - result.systemout ShouldContainSubstring "return code"
+    - result.systemerr ShouldContainSubstring "retry failed"
+
+- name: test-stop-on-exit-code-no-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-on-exit "3,4" --max-tries 2 "sh -c 'exit 1'"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemout ShouldContainSubstring "attempt n°"
+    - result.systemerr ShouldContainSubstring "max tries reached"
+
+- name: test-stop-on-exit-code-success-continues
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-on-exit "1,2" "echo success"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "success"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-stop-when-output-contains-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-when-contains "success" --max-tries 5 "echo 'operation success completed'"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "operation success completed"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-stop-when-output-contains-no-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-when-contains "success" --max-tries 2 "echo 'operation failed'"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "operation failed"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-stop-when-output-not-contains-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-when-not-contains "error" --max-tries 5 "echo 'operation completed successfully'"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "operation completed successfully"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-stop-when-output-not-contains-no-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-when-not-contains "error" --max-tries 2 "sh -c 'echo error occurred; exit 1'"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemout ShouldContainSubstring "error occurred"
+    - result.systemout ShouldContainSubstring "attempt n°"
+
+- name: test-stop-when-output-regex-pattern
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-when-contains "\\d+ files processed" --max-tries 5 "echo 'Successfully processed 42 files processed'"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "42 files processed"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-timeout-condition
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --timeout 100ms --delay 50ms "sh -c 'sleep 0.2; echo done'"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemout ShouldContainSubstring "attempt n°"
+    - result.systemerr ShouldContainSubstring "context error"
+
+- name: test-timeout-condition-success-before-timeout
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --timeout 1s "echo quick success"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "quick success"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-stop-at-time-future
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      # Test with a time far in the future (23:59) - should not stop immediately
+      go run cmd/* --stop-at "23:59" --max-tries 2 "echo time test"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "time test"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-invalid-exit-codes
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-on-exit "invalid,1" "echo test"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemerr ShouldContainSubstring "invalid exit code"
+
+- name: test-invalid-timeout-format
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --timeout "invalid" "echo test"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemerr ShouldContainSubstring "invalid timeout format"
+
+- name: test-invalid-time-format
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --stop-at "25:00" "echo test"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemerr ShouldContainSubstring "invalid time format"
+
+# =============================================================================
+# COMPOSITE CONDITION TESTS
+# =============================================================================
+
+- name: test-composite-and-logic-both-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --max-tries 1 --stop-on-exit "1" --condition-logic "and" "sh -c 'exit 1'"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemout ShouldContainSubstring "attempt n°"
+    - result.systemerr ShouldContainSubstring "max tries reached"
+
+- name: test-composite-or-logic-one-match
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --max-tries 5 --stop-on-exit "1" --condition-logic "or" "sh -c 'exit 1'"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemout ShouldContainSubstring "attempt n°"
+    - result.systemerr ShouldContainSubstring "retry failed"
+
+- name: test-composite-multiple-conditions
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --max-tries 10 --stop-on-exit "2" --stop-when-contains "success" --condition-logic "or" "echo 'operation success'"
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring "operation success"
+    - result.systemout ShouldContainSubstring "Command executed successfully"
+
+- name: test-composite-timeout-with-max-tries
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --timeout 200ms --max-tries 10 --delay 50ms --condition-logic "or" "sh -c 'sleep 0.3; echo done'"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemout ShouldContainSubstring "attempt n°"
+    - result.systemerr ShouldContainSubstring "context error"
+
+- name: test-invalid-condition-logic
+  steps:
+  - type: exec
+    script: |
+      cd {{.venom.testsuite.workdir}}/..
+      go run cmd/* --condition-logic "invalid" "echo test"
+    assertions:
+    - result.code ShouldEqual 1
+    - result.systemerr ShouldContainSubstring "invalid condition logic"
+


### PR DESCRIPTION
- Added StopOnExitCode to stop retries based on specific exit codes.
- Introduced StopOnOutputPattern to stop retries based on output matching.
- Created StopAtTimeOfDay to stop retries at a specific time of day.
- Implemented StopOnTimeout for a straightforward timeout-based stop condition.
- Developed unit tests for all new stop conditions to ensure correct functionality.
- Updated testsuite.yml to include tests for new stop conditions and composite conditions.
