### PR TITLE
fix(logger): correct quiet mode output suppression

### DIFF
--- a/tests/testsuite.yml
+++ b/tests/testsuite.yml
@@ -1024,9 +1024,12 @@ testcases:
       go run ../cmd --quiet --max-tries 2 "echo 'quiet mode test'"
     assertions:
     - result.code ShouldEqual 0
-    - result.systemout ShouldContainSubstring "[1/2] Attempting command..."
-    - result.systemout ShouldContainSubstring "│ quiet mode test"
-    - result.systemout ShouldContainSubstring "✓ Success"
+    - result.systemout ShouldNotContainSubstring "[1/2] Attempting command..."
+    - result.systemout ShouldNotContainSubstring "│ quiet mode test"
+    - result.systemout ShouldNotContainSubstring "✓ Success"
+    - result.systemout ShouldContainSubstring "SUMMARY"
+    - result.systemout ShouldContainSubstring "Result"
+    - result.systemout ShouldContainSubstring "Success"
 
 - name: test-log-file-creation
   steps:


### PR DESCRIPTION
The --quiet flag was not properly suppressing attempt-by-attempt output.
Fixed by checking LogLevelQuiet in StartAttempt, EndAttempt, and
shouldSkipConsoleOutput methods.

Changes:
- Skip attempt messages in quiet mode (except quiet-retries mode)
- Skip command output in quiet mode (except quiet-retries mode)
- Always show summary in quiet mode (as the "final result")
- Update test expectations to verify quiet mode suppresses verbose output