### PR TITLE
refactor: fix linter issues and improve code quality

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,9 +24,9 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:
           repo: golangci/golangci-lint
-          tag: v2.4.0
+          tag: v2.6.1
           cache: enable
-          binaries-location: golangci-lint-2.4.0-linux-amd64
+          binaries-location: golangci-lint-2.6.1-linux-amd64
 
       - name: Run linter
         shell: /usr/bin/bash {0}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -27,8 +28,8 @@ const (
 
 var (
 	version = "dev"
-	
-	// Error definitions.
+
+	// ErrCommandRequired is returned when no command is provided as a positional argument.
 	ErrCommandRequired       = errors.New("command is required as a positional argument")
 	ErrCommandEmpty          = errors.New("command is required")
 	ErrInvalidMultiplier     = errors.New("multiplier must be greater than 1.0")
@@ -359,12 +360,10 @@ func validateLogLevel(cmd *cobra.Command) error {
 	}
 	
 	validLevels := []string{"error", "warn", "warning", "info", "debug"}
-	for _, level := range validLevels {
-		if strings.ToLower(finalLogLevel) == level {
-			return nil
-		}
+	if slices.Contains(validLevels, strings.ToLower(finalLogLevel)) {
+		return nil
 	}
-	
+
 	return ErrInvalidLogLevel
 }
 

--- a/pkg/retry/retry_conditions.go
+++ b/pkg/retry/retry_conditions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -45,15 +46,7 @@ func (r *RetryOnExitCode) EndTry() {}
 // SetLastExitCode updates the last exit code and determines if we should retry.
 func (r *RetryOnExitCode) SetLastExitCode(code int) {
 	r.lastExitCode = code
-	r.shouldRetry = false
-	
-	// Check if this exit code is in our retry list
-	for _, retryCode := range r.retryCodes {
-		if code == retryCode {
-			r.shouldRetry = true
-			return
-		}
-	}
+	r.shouldRetry = slices.Contains(r.retryCodes, code)
 }
 
 // SetLastOutput is not used by retry exit code condition.

--- a/pkg/retry/stop_exitcode.go
+++ b/pkg/retry/stop_exitcode.go
@@ -1,6 +1,9 @@
 package retry
 
-import "context"
+import (
+	"context"
+	"slices"
+)
 
 // StopOnExitCode stops retrying when a specific exit code is encountered.
 type StopOnExitCode struct {
@@ -37,15 +40,7 @@ func (s *StopOnExitCode) EndTry() {}
 // SetLastExitCode updates the last exit code and checks if we should stop.
 func (s *StopOnExitCode) SetLastExitCode(code int) {
 	s.lastExitCode = code
-	s.shouldStop = false
-	
-	// Check if this exit code is in our stop list
-	for _, stopCode := range s.stopCodes {
-		if code == stopCode {
-			s.shouldStop = true
-			return
-		}
-	}
+	s.shouldStop = slices.Contains(s.stopCodes, code)
 }
 
 // SetLastOutput is not used by exit code condition.

--- a/pkg/retry/success_conditions.go
+++ b/pkg/retry/success_conditions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -43,15 +44,7 @@ func (s *SuccessOnExitCode) EndTry() {}
 // SetLastExitCode updates the last exit code and checks for success.
 func (s *SuccessOnExitCode) SetLastExitCode(code int) {
 	s.lastExitCode = code
-	s.isSuccess = false
-	
-	// Check if this exit code is in our success list
-	for _, successCode := range s.successCodes {
-		if code == successCode {
-			s.isSuccess = true
-			return
-		}
-	}
+	s.isSuccess = slices.Contains(s.successCodes, code)
 }
 
 // SetLastOutput is not used by success exit code condition.


### PR DESCRIPTION
Multiple code quality improvements to satisfy golangci-lint:

- Replace interface{} with any for modern Go syntax
- Simplify exit code lookups using slices.Contains
- Reduce cyclomatic complexity in EndAttempt by extracting helpers
- Fix godoc comment format for ErrCommandRequired
- Reorder unexported methods after exported ones
- Update golangci-lint version to v2.6.1 in CI workflow

All changes maintain existing functionality while improving code readability
and following Go best practices.