### PR TITLE
chore: rename linter task to lint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run linter
         shell: /usr/bin/bash {0}
         run: |
-          task linter
+          task lint

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
       - CGO_ENABLED=0 go build -o {{.BINFILE}} cmd/*.go
     # silent: true
 
-  linter:
+  lint:
     desc: "Run linter"
     cmds:
       - golangci-lint run


### PR DESCRIPTION
Rename the Taskfile task from 'linter' to 'lint' for consistency
and brevity. Update GitHub Actions workflow to use the new name.